### PR TITLE
Backward compatibility for Python 3.5

### DIFF
--- a/core.py
+++ b/core.py
@@ -133,7 +133,7 @@ def build_graph(net):
     default_inputs = [[('input',)]]+[[k] for k in net.keys()]
     with_default_inputs = lambda vals: (val if isinstance(val, tuple) else (val, default_inputs[idx]) for idx,val in enumerate(vals))
     parts = lambda path, pfx: tuple(pfx) + path.parts if isinstance(path, RelativePath) else (path,) if isinstance(path, str) else path
-    return {sep.join((*pfx, name)): (val, [sep.join(parts(x, pfx)) for x in inputs]) for (*pfx, name), (val, inputs) in zip(net.keys(), with_default_inputs(net.values()))}
+    return {sep.join(map(str, (*pfx, name))): (val, [sep.join(map(str, parts(x, pfx))) for x in inputs]) for (*pfx, name), (val, inputs) in zip(net.keys(), with_default_inputs(net.values()))}
     
 
 #####################
@@ -216,7 +216,7 @@ def make_pydot(nodes, edges, direction='LR', sep=sep, **kwargs):
     stub = lambda path: path[-1]
     class Subgraphs(dict):
         def __missing__(self, path):
-            subgraph = pydot.Cluster(sep.join(path), label=stub(path), style='rounded, filled', fillcolor='#77777744')
+            subgraph = pydot.Cluster(sep.join(map(str, path)), label=stub(path), style='rounded, filled', fillcolor='#77777744')
             self[parent(path)].add_subgraph(subgraph)
             return subgraph
     subgraphs = Subgraphs()

--- a/core.py
+++ b/core.py
@@ -27,9 +27,9 @@ class TableLogger():
     def append(self, output):
         if not hasattr(self, 'keys'):
             self.keys = output.keys()
-            print(*(f'{k:>12s}' for k in self.keys))
+            print(*('{:>12s}'.format(k) for k in self.keys))
         filtered = [output[k] for k in self.keys]
-        print(*(f'{v:12.4f}' if isinstance(v, np.float) else f'{v:12}' for v in filtered))
+        print(*('{:12.4f}'.format(v) if isinstance(v, np.float) else '{:12}'.format(v) for v in filtered))
 
 #####################
 ## data preprocessing

--- a/dawn.py
+++ b/dawn.py
@@ -48,7 +48,7 @@ class TSVLogger():
         self.log = ['epoch\thours\ttop1Accuracy']
     def append(self, output):
         epoch, hours, acc = output['epoch'], output['total time']/3600, output['test acc']*100
-        self.log.append(f'{epoch}\t{hours:.8f}\t{acc:.2f}')
+        self.log.append('{}\t{:.8f}\t{:.2f}'.format(epoch, hours, acc))
     def __str__(self):
         return '\n'.join(self.log)
    
@@ -74,10 +74,10 @@ def main():
     
     print('Preprocessing training data')
     train_set = list(zip(transpose(normalise(pad(dataset['train']['data'], 4))), dataset['train']['labels']))
-    print(f'Finished in {timer():.2} seconds')
+    print('Finished in {:.2} seconds'.format(timer()))
     print('Preprocessing test data')
     test_set = list(zip(transpose(normalise(dataset['test']['data'])), dataset['test']['labels']))
-    print(f'Finished in {timer():.2} seconds')
+    print('Finished in {:.2} seconds'.format(timer())
     
     TSV = TSVLogger()
     

--- a/dawn.py
+++ b/dawn.py
@@ -50,7 +50,7 @@ class TSVLogger():
         epoch, hours, acc = output['epoch'], output['total time']/3600, output['test acc']*100
         self.log.append('{}\t{:.8f}\t{:.2f}'.format(epoch, hours, acc))
     def __str__(self):
-        return '\n'.join(self.log)
+        return '\n'.join(map(str, self.log))
    
 def main():
     DATA_DIR = './data'

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -123,10 +123,10 @@
     "t = Timer()\n",
     "print('Preprocessing training data')\n",
     "train_set = list(zip(transpose(normalise(pad(dataset['train']['data'], 4))), dataset['train']['labels']))\n",
-    "print(f'Finished in {t():.2} seconds')\n",
+    "print('Finished in {:.2} seconds'.format(t()))\n",
     "print('Preprocessing test data')\n",
     "test_set = list(zip(transpose(normalise(dataset['test']['data'])), dataset['test']['labels']))\n",
-    "print(f'Finished in {t():.2} seconds')"
+    "print('Finished in {:.2} seconds'.format(t()))"
    ]
   },
   {
@@ -827,15 +827,15 @@
     "\n",
     "summaries = []\n",
     "for i in range(N_runs):\n",
-    "    print(f'Starting Run {i} at {localtime()}')\n",
+    "    print('Starting Run {} at {}'.format(i, localtime()))\n",
     "    model = Network(union(net(), losses)).to(device).half()\n",
     "    opt = SGD(trainable_params(model), lr=lr, momentum=0.9, weight_decay=5e-4*batch_size, nesterov=True)\n",
     "    summaries.append(train(model, opt, train_batches, test_batches, epochs, loggers=(TableLogger(),)))\n",
     "\n",
     "test_accs = np.array([s['test acc'] for s in summaries])\n",
-    "print(f'mean test accuracy: {np.mean(test_accs):.4f}')\n",
-    "print(f'median test accuracy: {np.median(test_accs):.4f}')\n",
-    "print(f'{np.sum(test_accs>=0.94)}/{N_runs} >= 94%')"
+    "print('mean test accuracy: {:.4f}'.format(np.mean(test_accs)))\n",
+    "print('median test accuracy: {:.4f}'.format(np.median(test_accs)))\n",
+    "print('{}/{} >= 94%'.format(np.sum(test_accs>=0.94), N_runs))"
    ]
   },
   {

--- a/experiments.ipynb
+++ b/experiments.ipynb
@@ -192,10 +192,10 @@
     "t = Timer()\n",
     "print('Preprocessing training data')\n",
     "train_set = list(zip(transpose(normalise(pad(dataset['train']['data'], 4))), dataset['train']['labels']))\n",
-    "print(f'Finished in {t():.2} seconds')\n",
+    "print('Finished in {:.2} seconds'.format(t()))\n",
     "print('Preprocessing test data')\n",
     "test_set = list(zip(transpose(normalise(dataset['test']['data'])), dataset['test']['labels']))\n",
-    "print(f'Finished in {t():.2} seconds')"
+    "print('Finished in {:.2} seconds'.format(t()))"
    ]
   },
   {


### PR DESCRIPTION
Changes the format strings from f-strings (introduced in Python 3.6) to `str.format()` (which has been around since Python 2.6).

f-strings are great, but not universally supported yet - I made this change for myself because I'm using Ubuntu 16.04 LTS, which ships with Python 3.5.

I also needed to explicitly turn lists of objects into strings when they were being concatenated, using `map(str, x)`.

Thought I'd share this in case you wanted to incorporate it into the main code base.