### PR TITLE
BUG: data and target CIFAR10 fields for torchvision 0.2.2

### DIFF
--- a/torch_backend.py
+++ b/torch_backend.py
@@ -36,9 +36,14 @@ def warmup_cudnn(model, batch_size):
 def cifar10(root):
     train_set = torchvision.datasets.CIFAR10(root=root, train=True, download=True)
     test_set = torchvision.datasets.CIFAR10(root=root, train=False, download=True)
+    # Need to check for both naming conventions used in torchvision >=0.2.2
+    # (`data` and `targets`), and those from torchvision >=0.2.1 (train/test_set
+    # and train/test_labels)
     return {
-        'train': {'data': train_set.train_data, 'labels': train_set.train_labels},
-        'test': {'data': test_set.test_data, 'labels': test_set.test_labels}
+        'train': {'data': train_set.data if hasattr(train_set, 'data') else train_set.train_data,
+                  'labels': train_set.targets if hasattr(train_set, 'targets') else train_set.train_labels},
+        'test': {'data': test_set.data if hasattr(test_set, 'data') else test_set.test_data,
+                 'labels': test_set.targets if hasattr(test_set, 'targets') else test_set.test_labels},
     }
 
 #####################


### PR DESCRIPTION
In the latest release of torchvision (v0.2.2), the fields of the
CIFAR10 object containing the data were changed from
- both `train_data` and `test_data` to `data`
- both `train_labels` and `test_labels` to `targets`
https://github.com/pytorch/vision/releases/tag/v0.2.2
These changes were made in PR
https://github.com/pytorch/vision/pull/594

Our code is pulling the data out from the old fields, which are
not supported in current and future versions of torchvision.

To ensure we can support both torchvision <=0.2.1 and >=0.2.2,
the fix checks for and uses whichever of these two versions exists
(with a preference for the new naming convention if it is available).